### PR TITLE
Change bootstap-sass dependency to 3.1.1

### DIFF
--- a/templates/bower.json
+++ b/templates/bower.json
@@ -18,7 +18,7 @@
     <% if (projectCss === 'bourbon/neat') { %>
     "normalize-scss": "~3.0.3"
     <% } else if (projectCss === 'bootstrap') { %>
-    "bootstrap-sass": "~3.3.4"
+    "bootstrap-sass": "3.3.1"
     <% } else {} %>
   }
 }


### PR DESCRIPTION
Hey,

When initially building the scaffold you'll get an error that bootstap _forms can't build or is missing.  I reverted back to 3.3.1 and everything seems to be okay.
